### PR TITLE
audio/wiiu: FIx right audio channel

### DIFF
--- a/src/audio/wiiu/SDL_wiiuaudio.h
+++ b/src/audio/wiiu/SDL_wiiuaudio.h
@@ -40,6 +40,8 @@ struct SDL_PrivateAudioData {
     Uint8   *rawbuf;
     /* Individual mixing buffers. */
     Uint8   *mixbufs[NUM_BUFFERS];
+    /* Deinterleaving buffer. */
+    Uint8   *deintvbuf;
 
     int renderingid;
     int playingid;


### PR DESCRIPTION
The deinterleaving algorithm ended up overwriting the first half of the right channel buffer